### PR TITLE
Re-enable Cohere re-ranking in query pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The bot automatically responds to questions in Slack channels dedicated to DataT
 
 - **Searching indexed course materials** including FAQ documents, Slack history, GitHub repositories, and YouTube subtitles
 - **Using vector similarity search** to find the most relevant content for each question
+- **Re-ranking results** with Cohere's re-ranking model to improve relevance
 - **Generating contextual answers** using GPT-4o-mini based on retrieved course materials
 - **Providing source references** with links back to original materials (Slack messages, docs, GitHub files, videos)
 - **Learning from feedback** through upvote/downvote reactions tracked via LangSmith
@@ -25,7 +26,8 @@ The system consists of two main components:
 - Runs as a Slack app using Socket Mode with the Slack Bolt framework
 - Maintains 4 separate query engines (ML, DE, MLOps, LLM Zoomcamps)
 - Uses LlamaIndex with Milvus/Zilliz vector store and HuggingFace embeddings
-- Implements time-weighted post-processing to prioritize recent Slack messages
+- Implements time-weighted post-processing to prioritize recent Slack messages (applied first)
+- Implements Cohere re-ranking to improve result relevance (20 retrieved → 10 after time-weighting → 4 after re-ranking)
 
 ### 2. Ingestion Pipeline (`ingest/`)
 - Indexes data from multiple sources: Google Docs (FAQs), Slack history, GitHub repos, YouTube subtitles
@@ -110,6 +112,7 @@ For more details, see [`ingest/local_development.md`](ingest/local_development.m
 - `SLACK_BOT_TOKEN` - Bot token for Slack app
 - `SLACK_APP_TOKEN` - App-level token for Socket Mode
 - `OPENAI_API_KEY` - OpenAI API key for GPT-4o-mini
+- `COHERE_API_KEY` - Cohere API key for result re-ranking
 - `ZILLIZ_CLOUD_URI`, `ZILLIZ_CLOUD_API_KEY` - For ML/DE Zoomcamps
 - `ZILLIZ_PUBLIC_ENDPOINT`, `ZILLIZ_API_KEY` - For MLOps/LLM Zoomcamps
 - `LANGCHAIN_API_KEY`, `LANGCHAIN_PROJECT` - For LangSmith logging
@@ -143,6 +146,7 @@ For more details, see [`ingest/local_development.md`](ingest/local_development.m
 - **LLM Framework**: LlamaIndex
 - **Vector Database**: Milvus (local), Zilliz Cloud (production)
 - **Embeddings**: HuggingFace BAAI/bge-base-en-v1.5
+- **Re-ranking**: Cohere Rerank API
 - **LLM**: OpenAI GPT-4o-mini
 - **Slack Integration**: Slack Bolt (Socket Mode)
 - **Observability**: LangSmith

--- a/slack_bot/main.py
+++ b/slack_bot/main.py
@@ -440,9 +440,16 @@ def get_retriever_query_engine(collection_name: str,
                                              overwrite=False)
     vector_store_index = VectorStoreIndex.from_vector_store(vector_store,
                                                             embed_model=embeddings)
-    cohere_rerank = CohereRerank(api_key=os.getenv('COHERE_API_KEY'), top_n=4)
     recency_postprocessor = get_time_weighted_postprocessor()
-    node_postprocessors = [recency_postprocessor, cohere_rerank]
+
+    # Validate COHERE_API_KEY and configure postprocessors
+    cohere_api_key = os.getenv('COHERE_API_KEY')
+    if not cohere_api_key:
+        logger.warning("COHERE_API_KEY not set, skipping Cohere re-ranking")
+        node_postprocessors = [recency_postprocessor]
+    else:
+        cohere_rerank = CohereRerank(api_key=cohere_api_key, top_n=4)
+        node_postprocessors = [recency_postprocessor, cohere_rerank]
     qa_prompt_template = get_prompt_template(zoomcamp_name=zoomcamp_name,
                                              cohort_year=cohort_year,
                                              course_start_date=course_start_date)

--- a/slack_bot/main.py
+++ b/slack_bot/main.py
@@ -16,7 +16,7 @@ from llama_index.core import get_response_synthesizer
 from llama_index.core.llms import ChatMessage, MessageRole
 from llama_index.core.postprocessor import TimeWeightedPostprocessor
 from llama_index.core.query_engine import RetrieverQueryEngine
-# from llama_index.postprocessor.cohere_rerank import CohereRerank
+from llama_index.postprocessor.cohere_rerank import CohereRerank
 from llama_index.vector_stores.milvus import MilvusVectorStore
 from llama_index.embeddings.huggingface import HuggingFaceEmbedding
 from requests.exceptions import ChunkedEncodingError
@@ -440,10 +440,9 @@ def get_retriever_query_engine(collection_name: str,
                                              overwrite=False)
     vector_store_index = VectorStoreIndex.from_vector_store(vector_store,
                                                             embed_model=embeddings)
-    # cohere_rerank = CohereRerank(api_key=os.getenv('COHERE_API_KEY'), top_n=4)
+    cohere_rerank = CohereRerank(api_key=os.getenv('COHERE_API_KEY'), top_n=4)
     recency_postprocessor = get_time_weighted_postprocessor()
-    # node_postprocessors = [recency_postprocessor, cohere_rerank]
-    node_postprocessors = [recency_postprocessor]
+    node_postprocessors = [recency_postprocessor, cohere_rerank]
     qa_prompt_template = get_prompt_template(zoomcamp_name=zoomcamp_name,
                                              cohort_year=cohort_year,
                                              course_start_date=course_start_date)
@@ -453,7 +452,7 @@ def get_retriever_query_engine(collection_name: str,
     response_synthesizer = get_response_synthesizer(text_qa_template=qa_prompt_template,
                                                     verbose=True,
                                                     )
-    return RetrieverQueryEngine(vector_store_index.as_retriever(similarity_top_k=15),
+    return RetrieverQueryEngine(vector_store_index.as_retriever(similarity_top_k=20),
                                 node_postprocessors=node_postprocessors,
                                 response_synthesizer=response_synthesizer,
                                 )


### PR DESCRIPTION
## Summary
- Re-enabled Cohere re-ranking (was previously commented out)
- Optimized the post-processing pipeline with two-stage approach:
  - Time-weighted postprocessor first (20 → 10 results) to prioritize recent Slack messages
  - Cohere re-ranking second (10 → 4 results) for semantic relevance
- Increased initial retrieval from 15 to 20 results to provide more candidates
- Documented the complete pipeline flow and rationale in README.md and CLAUDE.md
- Added COHERE_API_KEY to required environment variables documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)