### PR TITLE
chore: optimize Docker CI workflow and clean up unused imports

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -30,6 +30,13 @@ jobs:
       - name: Push tagged image to Docker Hub
         run: docker push aaalexlit/faq-slack-bot:previous
 
+      - name: Remove pulled images to free space
+        run: |
+          docker rmi aaalexlit/faq-slack-bot:main || true
+          docker rmi aaalexlit/faq-slack-bot:previous || true
+          docker system prune -af --volumes || true
+          docker builder prune -af || true
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -39,11 +46,16 @@ jobs:
             type=sha
             type=ref,event=branch
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./slack_bot/
           file: ./slack_bot/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/ingest/de/ingest_de.py
+++ b/ingest/de/ingest_de.py
@@ -1,7 +1,7 @@
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from ingest.utils.index_utils import index_spreadsheet, index_github_repo, \
+from ingest.utils.index_utils import index_github_repo, \
     index_slack_history, index_faq, index_youtube
 
 DE_CHANNEL_ID = 'C01FABYF2RG'


### PR DESCRIPTION
## Summary
- Add Docker layer caching via GitHub Actions cache to speed up builds
- Add image cleanup step to free disk space in CI environment
- Update docker/build-push-action from v5 to v6 and add Buildx setup
- Remove unused `index_spreadsheet` import from DE ingestion script

## Test plan
- [ ] Verify Docker CI workflow runs successfully
- [ ] Check that Docker layer caching is working
- [ ] Confirm no regression in DE ingestion functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)