### PR TITLE
Fix: Reduce Docker image size below 8GB limit

### DIFF
--- a/slack_bot/Dockerfile
+++ b/slack_bot/Dockerfile
@@ -1,12 +1,14 @@
 FROM python:3.10-slim
 
-RUN apt-get update && \
-    apt-get install -y gcc python3-dev
-
 WORKDIR /usr/src/app
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+
+# Install Python packages (all should have pre-built wheels)
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip cache purge && \
+    find /usr/local -type f -name '*.pyc' -delete && \
+    find /usr/local -type d -name '__pycache__' -delete
 
 COPY main.py ./
 

--- a/slack_bot/requirements.txt
+++ b/slack_bot/requirements.txt
@@ -1,3 +1,7 @@
+# Install CPU-only PyTorch first to avoid CUDA bloat (saves ~3GB)
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.9.1+cpu
+
 openai==1.61.0
 slack-bolt==1.22.0
 slack-sdk==3.34.0


### PR DESCRIPTION
## Summary
- Switch to CPU-only PyTorch to avoid CUDA dependencies (~3GB savings)
- Remove unnecessary build tools (gcc, python3-dev)
- Add cleanup steps for .pyc files and pip cache

## Problem
Deployment to Fly.io was failing with "Not enough space to unpack image, possibly exceeds maximum of 8GB uncompressed"

## Solution
The bot only needs PyTorch for embedding queries at runtime, not for GPU acceleration. Using `torch==2.9.1+cpu` significantly reduces the image size while maintaining full functionality.

## Test plan
- Build Docker image locally and verify size reduction
- Deploy to Fly.io and verify bot functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)