### PR TITLE
Fix: Reduce ingestion Docker image size

### DIFF
--- a/ingest/ingest.dockerfile
+++ b/ingest/ingest.dockerfile
@@ -1,22 +1,19 @@
 FROM python:3.10-slim
 
-# Install build tools, then clean up
-RUN apt-get update \
- && apt-get install -y --no-install-recommends gcc python3-dev \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
 RUN pip install --no-cache-dir -U pip
 
 WORKDIR /usr/src
 
-# Install Python requirements
+# Install Python requirements (all should have pre-built wheels)
 COPY ingest/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip cache purge && \
+    find /usr/local -type f -name '*.pyc' -delete && \
+    find /usr/local -type d -name '__pycache__' -delete
 
 # Copy ALL ingestion source code
 COPY ingest ingest
 
 # ---
-# We’ll always override the CMD from the workflow, so keep a lightweight default
+# We'll always override the CMD from the workflow, so keep a lightweight default
 CMD ["python", "-c", "print('Specify the component when you run the container, e.g. `docker run … python -m ingest.ml.ingest_ml`')"]

--- a/ingest/requirements.txt
+++ b/ingest/requirements.txt
@@ -1,3 +1,7 @@
+# Install CPU-only PyTorch first to avoid CUDA bloat (saves ~3GB)
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.9.1+cpu
+
 slack-sdk==3.30.0
 langchain==0.1.20
 python-frontmatter==1.0.0


### PR DESCRIPTION
## Summary
- Switch to CPU-only PyTorch to avoid CUDA dependencies (~3GB savings)
- Remove unnecessary build tools (gcc, python3-dev)
- Add cleanup steps for .pyc files and pip cache

## Problem
The ingestion Docker image uses the full PyTorch distribution with CUDA libraries, making it unnecessarily large.

## Solution
Since the ingestion pipeline only needs PyTorch for computing embeddings on CPU (not GPU acceleration), using `torch==2.9.1+cpu` significantly reduces the image size while maintaining full functionality.

## Test plan
- Build ingestion Docker image and verify size reduction
- Run ingestion workflows and verify functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)